### PR TITLE
Update getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,15 +28,8 @@ tinyauth:
 Make sure to set the labels according to your own setup, this guide includes the most basic ones.
 :::
 
-::: warning
-Tinyauth accepts a comma separated list of `username:password-hash` combinations. Make sure escape the dollar signs by doubling them (`$  $$`). Example:
-`user:$$2a$$10$$UdLYoJ5lgPsC0RKqYH/jMua7zIn0g9kPqWmhYayJYLaZQ/FTmH2/u` (username is `user` and password is `password`).
-:::
-
-::: tip
-There is a CLI command provided by tinyauth to generate your credentials: `docker compose run tinyauth user create --interactive`. For more information check [the CLI reference](./reference/cli.md).
-
-You can also use [the online service "IT Tools" to generate the password hash](https://it-tools.tech/) (specifically the bcrypt module).
+::: info
+Tinyauth accepts a comma separated list of `username:hash` combinations. Make sure escape the dollar signs by doubling them. If you are unsure on how to create your user you can use the tinyauth CLI by running `docker run -i -t --rm --name tinyauth ghcr.io/steveiliop56/tinyauth:v3 user create --interactive` or use [IT Tools](https://it-tools.tech/bcrypt) to generate the password hash.
 :::
 
 ::: tip
@@ -84,6 +77,5 @@ services:
     labels:
       traefik.enable: true
       traefik.http.routers.tinyauth.rule: Host(`tinyauth.example.com`)
-      traefik.http.services.tinyauth.loadbalancer.server.port: 3000
       traefik.http.middlewares.tinyauth.forwardauth.address: http://tinyauth:3000/api/auth/traefik
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ You can also use [the online service "IT Tools" to generate the password hash](h
 :::
 
 ::: tip
-Use this command to generate the `SECRET` value: `openssl rand -hex 16`
+Use this command to generate the `SECRET` value: `tr -dc A-Za-z0-9 </dev/urandom | head -c 32; echo`
 :::
 
 Then for every app you want tinyauth to protect just add the following label:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -13,6 +13,7 @@ To get started simply add the tinyauth service next to your traefik container:
 ```yaml
 tinyauth:
   image: ghcr.io/steveiliop56/tinyauth:v3
+  container_name: tinyauth
   environment:
     - SECRET=some-random-32-chars-string
     - APP_URL=https://tinyauth.example.com
@@ -39,7 +40,7 @@ You can also use [the online service "IT Tools" to generate the password hash](h
 :::
 
 ::: tip
-Use this command to generate the `SECRET` value: `tr -dc A-Za-z0-9 </dev/urandom | head -c 32; echo`
+Use this command to generate the `SECRET` value: `openssl rand -hex 16`
 :::
 
 Then for every app you want tinyauth to protect just add the following label:
@@ -58,6 +59,7 @@ Here is a full example with traefik, nginx and tinyauth:
 services:
   traefik:
     image: traefik:v3.3
+    container_name: traefik
     command: --api.insecure=true --providers.docker
     ports:
       - 80:80
@@ -66,6 +68,7 @@ services:
 
   whoami:
     image: traefik/whoami:latest
+    container_name: whoami
     labels:
       traefik.enable: true
       traefik.http.routers.nginx.rule: Host(`whoami.example.com`)
@@ -73,6 +76,7 @@ services:
 
   tinyauth:
     image: ghcr.io/steveiliop56/tinyauth:v3
+    container_name: tinyauth
     environment:
       - SECRET=some-random-32-chars-string
       - APP_URL=https://tinyauth.example.com

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -12,7 +12,6 @@ To get started simply add the tinyauth service next to your traefik container:
 
 ```yaml
 tinyauth:
-  container_name: tinyauth
   image: ghcr.io/steveiliop56/tinyauth:v3
   environment:
     - SECRET=some-random-32-chars-string
@@ -21,7 +20,6 @@ tinyauth:
   labels:
     traefik.enable: true
     traefik.http.routers.tinyauth.rule: Host(`tinyauth.example.com`)
-    traefik.http.services.tinyauth.loadbalancer.server.port: 3000
     traefik.http.middlewares.tinyauth.forwardauth.address: http://tinyauth:3000/api/auth/traefik
 ```
 
@@ -30,12 +28,18 @@ Make sure to set the labels according to your own setup, this guide includes the
 :::
 
 ::: warning
-Tinyauth accepts a comma separated list of `username:password-hash` combinations. To generate your hash go to [IT Tools](https://it-tools.tech/) and use the bcrypt module. Make sure to escape the hash by doubling every dollar sign. Example:
+Tinyauth accepts a comma separated list of `username:password-hash` combinations. Make sure escape the dollar signs by doubling them (`$  $$`). Example:
 `user:$$2a$$10$$UdLYoJ5lgPsC0RKqYH/jMua7zIn0g9kPqWmhYayJYLaZQ/FTmH2/u` (username is `user` and password is `password`).
 :::
 
 ::: tip
-You can also use the tinyauth CLI to generate your credentials. For more information check the CLI reference [here](./reference/cli.md).
+There is a CLI command provided by tinyauth to generate your credentials: `docker compose run tinyauth user create --interactive`. For more information check [the CLI reference](./reference/cli.md).
+
+You can also use [the online service "IT Tools" to generate the password hash](https://it-tools.tech/) (specifically the bcrypt module).
+:::
+
+::: tip
+Use this command to generate the `SECRET` value: `tr -dc A-Za-z0-9 </dev/urandom | head -c 32; echo`
 :::
 
 Then for every app you want tinyauth to protect just add the following label:
@@ -53,7 +57,6 @@ Here is a full example with traefik, nginx and tinyauth:
 ```yaml
 services:
   traefik:
-    container_name: traefik
     image: traefik:v3.3
     command: --api.insecure=true --providers.docker
     ports:
@@ -62,16 +65,13 @@ services:
       - /var/run/docker.sock:/var/run/docker.sock
 
   whoami:
-    container_name: whoami
     image: traefik/whoami:latest
     labels:
       traefik.enable: true
       traefik.http.routers.nginx.rule: Host(`whoami.example.com`)
-      traefik.http.services.nginx.loadbalancer.server.port: 80
       traefik.http.routers.nginx.middlewares: tinyauth
 
   tinyauth:
-    container_name: tinyauth
     image: ghcr.io/steveiliop56/tinyauth:v3
     environment:
       - SECRET=some-random-32-chars-string

--- a/docs/guides/access-controls.md
+++ b/docs/guides/access-controls.md
@@ -19,7 +19,6 @@ tinyauth:
   labels:
     traefik.enable: true
     traefik.http.routers.tinyauth.rule: Host(`tinyauth.example.com`)
-    traefik.http.services.tinyauth.loadbalancer.server.port: 3000
     traefik.http.middlewares.tinyauth.forwardauth.address: http://tinyauth:3000/api/auth/traefik
 ```
 
@@ -36,7 +35,6 @@ whoami:
   labels:
     traefik.enable: true
     traefik.http.routers.nginx.rule: Host(`whoami.example.com`)
-    traefik.http.services.nginx.loadbalancer.server.port: 80
     traefik.http.routers.nginx.middlewares: tinyauth
     tinyauth.oauth.whitelist: user2@example.com # <- Added line
     tinyauth.users: user1 # <- Added line

--- a/docs/guides/allowed-paths.md
+++ b/docs/guides/allowed-paths.md
@@ -19,7 +19,6 @@ tinyauth:
   labels:
     traefik.enable: true
     traefik.http.routers.tinyauth.rule: Host(`tinyauth.example.com`)
-    traefik.http.services.tinyauth.loadbalancer.server.port: 3000
     traefik.http.middlewares.tinyauth.forwardauth.address: http://tinyauth:3000/api/auth/traefik
 ```
 
@@ -34,7 +33,6 @@ whoami:
   labels:
     traefik.enable: true
     traefik.http.routers.nginx.rule: Host(`whoami.example.com`)
-    traefik.http.services.nginx.loadbalancer.server.port: 80
     traefik.http.routers.nginx.middlewares: tinyauth
     tinyauth.allowed: \/api.*
 ```

--- a/docs/guides/github-app-oauth.md
+++ b/docs/guides/github-app-oauth.md
@@ -56,7 +56,6 @@ tinyauth:
   labels:
     traefik.enable: true
     traefik.http.routers.tinyauth.rule: Host(`tinyauth.example.com`)
-    traefik.http.services.tinyauth.loadbalancer.server.port: 3000
     traefik.http.middlewares.tinyauth.forwardauth.address: http://tinyauth:3000/api/auth/traefik
 ```
 

--- a/docs/guides/github-oauth.md
+++ b/docs/guides/github-oauth.md
@@ -52,7 +52,6 @@ tinyauth:
   labels:
     traefik.enable: true
     traefik.http.routers.tinyauth.rule: Host(`tinyauth.example.com`)
-    traefik.http.services.tinyauth.loadbalancer.server.port: 3000
     traefik.http.middlewares.tinyauth.forwardauth.address: http://tinyauth:3000/api/auth/traefik
 ```
 

--- a/docs/guides/google-oauth.md
+++ b/docs/guides/google-oauth.md
@@ -72,7 +72,6 @@ tinyauth:
   labels:
     traefik.enable: true
     traefik.http.routers.tinyauth.rule: Host(`tinyauth.example.com`)
-    traefik.http.services.tinyauth.loadbalancer.server.port: 3000
     traefik.http.middlewares.tinyauth.forwardauth.address: http://tinyauth:3000/api/auth/traefik
 ```
 

--- a/docs/guides/tailscale-oauth.md
+++ b/docs/guides/tailscale-oauth.md
@@ -33,7 +33,6 @@ tinyauth:
   labels:
     traefik.enable: true
     traefik.http.routers.tinyauth.rule: Host(`tinyauth.example.com`)
-    traefik.http.services.tinyauth.loadbalancer.server.port: 3000
     traefik.http.middlewares.tinyauth.forwardauth.address: http://tinyauth:3000/api/auth/traefik
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -16,6 +16,10 @@ As well as when the app is running through docker:
 docker run -i -t --rm --name tinyauth ghcr.io/steveiliop56/tinyauth:v3 [options]
 ```
 
+::: info
+If you are using docker compose you can also use `docker compose run tinyauth [options]`.
+:::
+
 ### Main command
 
 The main command is the one run when you run the app without any flags/arguments. It stars the API and web UI and waits for incoming connections. All the options are configurable with both CLI flags and environment variables. To find a list of available configuration options please go to the [configuration](./configuration.md) section.


### PR DESCRIPTION
Hi there!

I've changed a couple of things in this basically nice document.

- container_name: this isn't necessary as the container is reachable via DNS by it's service name
- I've swapped your password hash suggestions because you're provide a nice and convenient way which diesn't rely on external services. I think this should have the preference as it's a very nice feature
- also I've added a shell command to cretae the 32 character secret as most user would otherwise start to search for a way to generate it