### PR TITLE
Set all containers to default to restart unless stopped

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -14,6 +14,7 @@ To get started simply add the tinyauth service next to your traefik container:
 tinyauth:
   image: ghcr.io/steveiliop56/tinyauth:v3
   container_name: tinyauth
+  restart: unless-stopped
   environment:
     - SECRET=some-random-32-chars-string
     - APP_URL=https://tinyauth.example.com
@@ -54,6 +55,7 @@ services:
     image: traefik:v3.3
     container_name: traefik
     command: --api.insecure=true --providers.docker
+    restart: unless-stopped
     ports:
       - 80:80
     volumes:
@@ -62,6 +64,7 @@ services:
   whoami:
     image: traefik/whoami:latest
     container_name: whoami
+    restart: unless-stopped
     labels:
       traefik.enable: true
       traefik.http.routers.nginx.rule: Host(`whoami.example.com`)
@@ -70,6 +73,7 @@ services:
   tinyauth:
     image: ghcr.io/steveiliop56/tinyauth:v3
     container_name: tinyauth
+    restart: unless-stopped
     environment:
       - SECRET=some-random-32-chars-string
       - APP_URL=https://tinyauth.example.com

--- a/docs/guides/access-controls.md
+++ b/docs/guides/access-controls.md
@@ -10,6 +10,7 @@ We firstly need to make some small changes to the tinyauth container. We will us
 tinyauth:
   container_name: tinyauth
   image: ghcr.io/steveiliop56/tinyauth:v3
+  restart: unless-stopped
   environment:
     - SECRET=some-random-32-chars-string
     - APP_URL=https://tinyauth.example.com
@@ -32,6 +33,7 @@ Now let's take the nginx example from the getting started guide and add the acce
 whoami:
   container_name: whoami
   image: traefik/whoami:latest
+  restart: unless-stopped
   labels:
     traefik.enable: true
     traefik.http.routers.nginx.rule: Host(`whoami.example.com`)

--- a/docs/guides/allowed-paths.md
+++ b/docs/guides/allowed-paths.md
@@ -10,6 +10,7 @@ We firstly need to make some small changes to the tinyauth container. We will us
 tinyauth:
   container_name: tinyauth
   image: ghcr.io/steveiliop56/tinyauth:v3
+  restart: unless-stopped
   environment:
     - SECRET=some-random-32-chars-string
     - APP_URL=https://tinyauth.example.com
@@ -30,6 +31,7 @@ Now let's take the nginx example from the getting started guide and add the acce
 whoami:
   container_name: whoami
   image: traefik/whoami:latest
+  restart: unless-stopped
   labels:
     traefik.enable: true
     traefik.http.routers.nginx.rule: Host(`whoami.example.com`)

--- a/docs/guides/github-app-oauth.md
+++ b/docs/guides/github-app-oauth.md
@@ -47,6 +47,7 @@ Now that we have our client ID and secret, we can pass it to the tinyauth docker
 tinyauth:
   container_name: tinyauth
   image: ghcr.io/steveiliop56/tinyauth:v3
+  restart: unless-stopped
   environment:
     - SECRET=some-random-32-chars-string
     - APP_URL=https://tinyauth.example.com

--- a/docs/guides/github-oauth.md
+++ b/docs/guides/github-oauth.md
@@ -43,6 +43,7 @@ Now that we have our client ID and secret, we can pass it to the tinyauth docker
 tinyauth:
   container_name: tinyauth
   image: ghcr.io/steveiliop56/tinyauth:v3
+  restart: unless-stopped
   environment:
     - SECRET=some-random-32-chars-string
     - APP_URL=https://tinyauth.example.com

--- a/docs/guides/google-oauth.md
+++ b/docs/guides/google-oauth.md
@@ -63,6 +63,7 @@ Now that we have our client ID and secret, we can pass it to the tinyauth docker
 tinyauth:
   container_name: tinyauth
   image: ghcr.io/steveiliop56/tinyauth:v3
+  restart: unless-stopped
   environment:
     - SECRET=some-random-32-chars-string
     - APP_URL=https://tinyauth.example.com

--- a/docs/guides/nginx-proxy-manager.md
+++ b/docs/guides/nginx-proxy-manager.md
@@ -32,6 +32,7 @@ services:
   tinyauth:
     container_name: tinyauth
     image: ghcr.io/steveiliop56/tinyauth:v3
+    restart: unless-stopped
     environment:
       - SECRET_FILE=/secret.txt
       - APP_URL=http://tinyauth.example.com

--- a/docs/guides/tailscale-oauth.md
+++ b/docs/guides/tailscale-oauth.md
@@ -25,6 +25,7 @@ Now that we have our client ID and secret, we can pass it to the tinyauth docker
 tinyauth:
   container_name: tinyauth
   image: ghcr.io/steveiliop56/tinyauth:v3
+  restart: unless-stopped
   environment:
     - SECRET=some-random-32-chars-string
     - APP_URL=https://tinyauth.example.com


### PR DESCRIPTION
That's already done in few places and results in more predictable behavior. Especially the current configuration for nginx-proxy-manager can cause problems, as npm is restarted (e.g. on reboot) and tries to reach tinyauth, which however doesn't restart. If you've configured your stack via Portainer and are at a point, where you access portainer via npm it's quite an headache to troubleshoot :wink: 