### PR TITLE
feat: add new remote headers to zitadel-oauth example

### DIFF
--- a/docs/community/zitadel-oauth.md
+++ b/docs/community/zitadel-oauth.md
@@ -47,7 +47,7 @@ tinyauth:
   environment:
     - SECRET=some-random-32-chars-string
     - APP_URL=https://tinyauth.example.com
-    - GENERIC_SCOPES="openid profile email prefered_username groups"
+    - GENERIC_SCOPES="openid profile email preferred_username groups"
     - GENERIC_AUTH_URL=https://zitadel.example.com/oauth/v2/authorize
     - GENERIC_TOKEN_URL=https://zitadel.example.com/oauth/v2/token
     - GENERIC_USER_URL=https://zitadel.example.com/oidc/v1/userinfo
@@ -60,7 +60,7 @@ tinyauth:
     traefik.enable: true
     traefik.http.routers.tinyauth.rule: Host(`tinyauth.example.com`)
     traefik.http.middlewares.tinyauth.forwardauth.address: http://tinyauth:3000/api/auth/traefik
-    traefik.http.middlewares.test-auth.forwardauth.authResponseHeaders: Remote-User, Remote-Email, Remote-Name, Remote-Groups
+    traefik.http.middlewares.tinyauth.forwardauth.authResponseHeaders: Remote-User, Remote-Email, Remote-Name, Remote-Groups
 ```
 
 ::: warning

--- a/docs/community/zitadel-oauth.md
+++ b/docs/community/zitadel-oauth.md
@@ -47,17 +47,20 @@ tinyauth:
   environment:
     - SECRET=some-random-32-chars-string
     - APP_URL=https://tinyauth.example.com
-    - GENERIC_SCOPES=email
+    - GENERIC_SCOPES="openid profile email prefered_username groups"
     - GENERIC_AUTH_URL=https://zitadel.example.com/oauth/v2/authorize
     - GENERIC_TOKEN_URL=https://zitadel.example.com/oauth/v2/token
     - GENERIC_USER_URL=https://zitadel.example.com/oidc/v1/userinfo
     - GENERIC_CLIENT_ID= # Paste from previous step
     - GENERIC_CLIENT_SECRET= # Paste from previous step
     - GENERIC_NAME=Zitadel
+    - OAUTH_AUTO_REDIRECT=generic
+    - DISABLE_CONTINUE=true
   labels:
     traefik.enable: true
     traefik.http.routers.tinyauth.rule: Host(`tinyauth.example.com`)
     traefik.http.middlewares.tinyauth.forwardauth.address: http://tinyauth:3000/api/auth/traefik
+    traefik.http.middlewares.test-auth.forwardauth.authResponseHeaders: Remote-User, Remote-Email, Remote-Name, Remote-Groups
 ```
 
 ::: warning


### PR DESCRIPTION
Added more config to zitadel oauth to use the new remote headers 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated instructions for Zitadel OAuth integration, including expanded OAuth scopes and new environment variables for improved authentication flow.
  - Added guidance on configuring Traefik middleware to forward user information headers after authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->