### PR TITLE
Make get-started page openssl command more readable

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -82,7 +82,7 @@ tinyauth:
 ```
 
 :::tip
-You can generate the `SECRET` environment variable using `openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | head -c 32`.
+You can generate the `SECRET` environment variable using `openssl rand -base64 32 | tr -dc 'a-zA-Z0-9' | head -c 32 && echo`
 :::
 
 Then for every app you want tinyauth to protect, just add the following label:


### PR DESCRIPTION
Improve readability and avoid confusion by:
1. Make [get-started](https://tinyauth.app/docs/getting-started) page `openssl` output more readable by adding `echo` to end of the command. This makes shell prompt `#` appear on next line. 
2. Removed ending period to avoid confusion

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the setup instructions for generating the `SECRET` environment variable to improve the shell command example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->