### PR TITLE
fix: make basic auth docs clearer

### DIFF
--- a/docs/guides/access-controls.md
+++ b/docs/guides/access-controls.md
@@ -7,11 +7,30 @@ Tinyauth supports basic access controls with docker labels. You can use them to 
 We firstly need to make one small change to the Tinyauth container. You will need to add the following volume:
 
 ```yaml
-volumes:
-  - /var/run/docker.sock:/var/run/docker.sock
+services:
+  # ...
+  tinyauth:
+    # ...
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
 ```
 
 Make sure to restart Tinyauth after setting the volume.
+
+:::tip
+For increased security, use a Docker socket proxy like [Tecnativa's](https://github.com/Tecnativa/docker-socket-proxy). You can then configure Tinyauth to use the proxy instead of binding to the socket. This can be done by adding the following environment variable to the Tinyauth container:
+
+```yaml
+services:
+  # ...
+  tinyauth:
+    # ...
+    environment:
+      DOCKER_HOST: tcp://docker-socket-proxy:2375
+```
+
+Make sure that Tinyauth can reach the docker socket proxy container.
+:::
 
 ## Label discovery
 

--- a/docs/guides/advanced.md
+++ b/docs/guides/advanced.md
@@ -4,33 +4,36 @@
 
 Some apps already offer some sort of authentication method like basic auth (the browser pop-up). This can be inconvenient because you may need to login both in Tinyauth and in the protected app. Tinyauth supports authenticating to apps for you. This can be done by adding the basic auth labels to your protected app:
 
-```yaml
-tinyauth.basic.username: username
-tinyauth.basic.password.plain: password
-```
+### Setup
 
-You will also need to add the following label to your Tinyauth container (assuming you are using Traefik for the reverse proxy and the middleware is called `tinyauth`):
+1. If you're using Traefik, add the following label to your Tinyauth container
 
-```yaml
-traefik.http.middlewares.tinyauth.forwardauth.authResponseHeaders: authorization
-```
+    ```yaml
+    # if you changed it, replace `tinyauth` with your own middleware name
+    traefik.http.middlewares.tinyauth.forwardauth.authResponseHeaders: authorization
+    ```
 
-After you restart your app and login to Tinyauth you should be automatically logged in to the protected app using basic auth.
+2. Make sure that Tinyauth can read the Docker labels by [connecting the Docker socket to the container](/docs/guides/access-controls.md#modifying-the-tinyauth-container)
+3. Add the Tinyauth labels to your service:
 
-:::tip
-You can use the `tinyauth.basic.password.file` label instead of the plain one so as your password can remain safe in a secret file. Make sure to add the secret file as a volume to Tinyauth.
-:::
+    ```yaml
+    services:
+      # ...
+      whoami:
+        # ...
+        labels:
+          # ...
+          tinyauth.basic.username: username
+          tinyauth.basic.password.plain: password
+          # if this doesn't work, try explicitly setting a domain
+          tinyauth.domain: whoami.example.com
+    ```
 
-## Socket Proxy
+    :::tip
+    You can use the `tinyauth.basic.password.file` label instead of the plain one so as your password can remain safe in a secret file. Make sure to add the secret file as a volume to Tinyauth.
+    :::
 
-For increased security you may be using a docker socket proxy like [Tecnativa's](https://github.com/Tecnativa/docker-socket-proxy), in this case you can configure Tinyauth to use the proxy instead of binding to the socket. This can be done by adding the following environment variable to the Tinyauth container:
-
-```sh
-DOCKER_HOST=tcp://docker-socket-proxy:2375
-```
-
-> [!WARNING]
-> Make sure that Tinyauth can reach the docker socket proxy container.
+4. After you restart your app and login to Tinyauth you should be automatically logged in to the protected app using basic auth.
 
 ## Host network and Traefik
 


### PR DESCRIPTION
I followed the basic auth docs but skipped over the access control section, and only realised what the problem was by looking at the debug logs (which showed no Docker connection).

I've tried to clarify this by moving the Docker socket instructions into the Access Control page which mentions the socket volume, and linking to it from the basic auth guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved instructions for modifying the Tinyauth container, including clearer YAML examples and a new security tip about using a Docker socket proxy.
  * Expanded and restructured the guide for authenticating to apps with basic auth, providing step-by-step setup instructions and clarifying Docker socket access requirements. 
  * Updated formatting and removed outdated recommendations regarding Docker socket proxy configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->