### PR TITLE
chore: enrich header section for necessity of passing header and exam…

### DIFF
--- a/docs/community/caddy.md
+++ b/docs/community/caddy.md
@@ -102,6 +102,7 @@ services:
       caddy: (tinyauth_forwarder)
       caddy.forward_auth: tinyauth:3000
       caddy.forward_auth.uri: /api/auth/caddy
+      caddy.forward_auth.copy_headers: Remote-User Remote-Name Remote-Email Remote-Groups # optional when you want to make headers available to your service
 
   tinyauth:
     container_name: tinyauth

--- a/docs/reference/headers.md
+++ b/docs/reference/headers.md
@@ -4,7 +4,9 @@ sidebar_position: 3
 
 # Headers
 
-Setting headers can be useful for authenticating to apps with the credentials from Tinyauth. While Tinyauth offers some defaults, it also allows you to set any headers you like that will be automatically returned in the authentication server response.
+Setting headers can be useful for authenticating to apps with the credentials from Tinyauth. While Tinyauth offers some defaults, it also allows you to set any headers you like that will be automatically returned in the authentication server response. This could be useful when your application supports header based authentication, where the app trusts the reverse proxy to provide the authentication and use the user information passed from the header.
+
+Note that the headers mentioned here is not automatically sent to the apps unless you specify it on the reverse proxy middleware you are using. See the section below for how to specify passing header in your reverse proxy.
 
 ## Supported headers
 
@@ -13,6 +15,10 @@ Setting headers can be useful for authenticating to apps with the credentials fr
 The `Remote-User` header contains the username of the currently logged in user.
 
 If you are using an OAuth provider, Tinyauth will try to retrieve the `preferred_username` claim from the OIDC response. If it isn't included in the response, Tinyauth will make a pseudo one using your email address in the format of `username_domain.com`.
+
+:::info
+Headers are case-insensitive. Therefore you can use either `Remote-User` or `remote-user` for specifying the header.
+:::
 
 ### Remote email
 
@@ -65,8 +71,10 @@ traefik.http.middlewares.tinyauth.forwardauth.authResponseHeaders: remote-user #
 Just add the following label in the Caddy labels:
 
 ```yaml
-caddy.forward_auth.copy_headers: remote-user # This can be a comma separated list of more headers you will like to copy like the custom ones you set
+caddy.forward_auth.copy_headers: remote-user
 ```
+
+Multiple headers here are separated by space. Therefore multiple headers are passed like `remote-user remote-name remote-email remote-groups`
 
 ### Nginx/Nginx Proxy Manager
 


### PR DESCRIPTION
…ple in caddy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Caddy service example to include an optional label for copying authentication-related headers.
  * Clarified how headers are set and forwarded in Tinyauth, including case-insensitivity of header names and details on specifying multiple headers in Caddy labels.
  * Added usage notes and examples to improve understanding of header-based authentication and proxy configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->