### PR TITLE
Fix several typos

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -4,11 +4,11 @@ sidebar_position: 1
 
 # About
 
-Before installing Tinyauth you may be wondering _Why should I use Tinyauth instead of Authelia/Authentik/Keycloack?_ which is a really valid question and I would like to answer in depth.
+Before installing Tinyauth you may be wondering _Why should I use Tinyauth instead of Authelia/Authentik/Keycloak?_ which is a really valid question and I would like to answer in depth.
 
 ## The issue with authentication in homelabs
 
-Most of us like using an authentication middleware in front of our apps to either protect them when they don't offer a login screen or just to add an additional layer of authentication. While the projects mentioned above can certainly do the job and offer a variety of configuration options, they can often be hard to configure for new users, resource hungry (apps like Authentik and Keycloack are designed for businesses and not the average homelabber) or simply too annoying to set up and maintain. This is where Tinyauth comes in.
+Most of us like using an authentication middleware in front of our apps to either protect them when they don't offer a login screen or just to add an additional layer of authentication. While the projects mentioned above can certainly do the job and offer a variety of configuration options, they can often be hard to configure for new users, resource hungry (apps like Authentik and Keycloak are designed for businesses and not the average homelabber) or simply too annoying to set up and maintain. This is where Tinyauth comes in.
 
 ## Why I created Tinyauth
 

--- a/docs/community/zitadel-oauth.md
+++ b/docs/community/zitadel-oauth.md
@@ -54,7 +54,7 @@ OAuth doesn't mean security, with the current setup everybody with a Zitadel acc
 :::
 
 :::tip
-Since you have OAuth enabled, you can now remove the `USERS` or `USERS_FILE` environment variables so as you can ony login with your OAuth provider.
+Since you have OAuth enabled, you can now remove the `USERS` or `USERS_FILE` environment variables so as you can only login with your OAuth provider.
 :::
 
 And you are done! After you restart Tinyauth and try to login to an app, you should have an additional option to login with Zitadel.

--- a/docs/guides/advanced.md
+++ b/docs/guides/advanced.md
@@ -37,7 +37,7 @@ Some apps already offer some sort of authentication method like basic auth (the 
 
 ## Host network and Traefik
 
-When using `network_mode: host` in docker alongside with Traefik, the `redirect_uri` in Tinyauth will always be the app URL instead of of the actual redirect URI. This is because Traefik does not respect the `X-Forwarded-Host` header from NAT IP addresses such as the docker internal one. This can be easily fixed by either using the following Traefik config:
+When using `network_mode: host` in docker alongside with Traefik, the `redirect_uri` in Tinyauth will always be the app URL instead of the actual redirect URI. This is because Traefik does not respect the `X-Forwarded-Host` header from NAT IP addresses such as the docker internal one. This can be easily fixed by either using the following Traefik config:
 
 ```yaml
 entryPoints:

--- a/docs/guides/github-app-oauth.md
+++ b/docs/guides/github-app-oauth.md
@@ -54,7 +54,7 @@ OAuth doesn't mean security, with the current setup everybody with a Github acco
 :::
 
 :::tip
-Since you have OAuth enabled, you can now remove the `USERS` or `USERS_FILE` environment variables so as you can ony login with your OAuth provider.
+Since you have OAuth enabled, you can now remove the `USERS` or `USERS_FILE` environment variables so as you can only login with your OAuth provider.
 :::
 
 And you are done! After you restart Tinyauth and try to login to an app, you should have an additional option to login with Github.

--- a/docs/guides/github-oauth.md
+++ b/docs/guides/github-oauth.md
@@ -50,7 +50,7 @@ OAuth doesn't mean security, with the current setup everybody with a Github acco
 :::
 
 :::tip
-Since you have OAuth enabled, you can now remove the `USERS` or `USERS_FILE` environment variables so as you can ony login with your OAuth provider.
+Since you have OAuth enabled, you can now remove the `USERS` or `USERS_FILE` environment variables so as you can only login with your OAuth provider.
 :::
 
 And you are done! After you restart Tinyauth and try to login to an app, you should have an additional option to login with Github.

--- a/docs/guides/google-oauth.md
+++ b/docs/guides/google-oauth.md
@@ -70,7 +70,7 @@ OAuth doesn't mean security, with the current setup everybody with a Github acco
 :::
 
 :::tip
-Since you have OAuth enabled, you can now remove the `USERS` or `USERS_FILE` environment variables so as you can ony login with your OAuth provider.
+Since you have OAuth enabled, you can now remove the `USERS` or `USERS_FILE` environment variables so as you can only login with your OAuth provider.
 :::
 
 And you are done! After you restart Tinyauth and try to login to an app, you should have an additional option to login with Google.

--- a/docs/guides/using-the-binary.md
+++ b/docs/guides/using-the-binary.md
@@ -71,7 +71,7 @@ Make sure to replace the paths in the service with the actual locations of your 
 :::
 
 :::tip
-If you are using CLI flags, you can remove the `EnvironmentFile` line and add your flags to to the `ExecStart` line, e.g. `ExecStart=/some/path/tinyauth --secret=secret --app-url=https://tinyauth.example.com`.
+If you are using CLI flags, you can remove the `EnvironmentFile` line and add your flags to the `ExecStart` line, e.g. `ExecStart=/some/path/tinyauth --secret=secret --app-url=https://tinyauth.example.com`.
 :::
 
 Finally we need to reload the systemd daemon:

--- a/docs/reference/headers.md
+++ b/docs/reference/headers.md
@@ -60,7 +60,7 @@ To add the headers to the proxy responses you need to configure your proxy to fo
 
 ### Traefik
 
-Just add the following in the Tinyauth container lables:
+Just add the following in the Tinyauth container labels:
 
 ```yaml
 traefik.http.middlewares.tinyauth.forwardauth.authResponseHeaders: remote-user # This can be a comma separated list of more headers you will like to copy like the custom ones you set


### PR DESCRIPTION
Noticed the `Keycloak` typo only at first, but I followed up with a quick pass and caught a few other typos, as described in each commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Fixed typos and wording across docs to improve clarity and professionalism.
  * Corrected “Keycloack” to “Keycloak” and “ony login” to “only login” in multiple OAuth guides.
  * Clarified notes about OAuth-only login behavior.
  * Fixed duplicated word in a systemd example and improved punctuation/line breaks.
  * Corrected “lables” to “labels” in headers reference.
  * Polished phrasing around redirect URI explanation.
  * No functional or configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->