### PR TITLE
Configuration FILE has no underscore

### DIFF
--- a/src/content/docs/docs/reference/configuration.mdx
+++ b/src/content/docs/docs/reference/configuration.mdx
@@ -6,8 +6,8 @@ description: Reference on Tinyauth's configuration.
 Tinyauth can be configured using environment variables or CLI flags. The table below provides a comprehensive list of configuration options.
 
 :::note
-  Configuration options with a `FILE_` equivalent (e.g., `USERS` and
-  `USERS_FILE`) allow the `FILE_` environment variable or CLI flag to be used as
+  Configuration options with a `FILE` equivalent (e.g., `USERS` and
+  `USERSFILE`) allow the `FILE` environment variable or CLI flag to be used as
   an alternative.
 :::
 


### PR DESCRIPTION
Remove the underscore from the example for the `FILE` options

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration reference documentation with improved examples and variable naming conventions for enhanced clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->