### PR TITLE
feat: document TINYAUTH_AUTH_STANDALONE option

### DIFF
--- a/src/content/docs/docs/getting-started.mdx
+++ b/src/content/docs/docs/getting-started.mdx
@@ -66,7 +66,7 @@ Multiple users can be created by repeating this process and separating entries w
 
 ## Domain Configuration
 
-Tinyauth sets a cookie for the parent domain of the application URL. For example, if the application URL is `http://tinyauth.example.com`, the cookie is set for `.example.com`, enabling authentication across all subdomains. Below is an example of an ideal domain structure:
+Tinyauth sets a cookie for the parent domain of the application URL, unless `TINYAUTH_AUTH_STANDALONE=true` is set. For example, if the application URL is `http://tinyauth.example.com`, the cookie is set for `.example.com`, enabling authentication across all subdomains. Below is an example of an ideal domain structure:
 
 ```mermaid
 flowchart BR
@@ -77,9 +77,10 @@ flowchart BR
 
 :::caution
   Direct usage with DDNS services (e.g., `tinyauth562.duckdns.org`) is not
-  supported due to browser cookie restrictions. Subdomains (e.g.,
-  `tinyauth.mylab562.duckdns.org`) must be used for both Tinyauth and
-  applications.
+  supported due to browser cookie restrictions unless
+  `TINYAUTH_AUTH_STANDALONE=true` is set. Subdomains (e.g.,
+  `tinyauth.mylab562.duckdns.org`) should be used if securing
+  both Tinyauth and applications is required.
 :::
 
 ## Deployment

--- a/src/content/docs/docs/reference/configuration.mdx
+++ b/src/content/docs/docs/reference/configuration.mdx
@@ -52,6 +52,7 @@ Tinyauth can be configured using environment variables or CLI flags. The table b
 | `TINYAUTH_AUTH_IP_BLOCK` | `--auth.ip.block` | List of blocked IPs or CIDR ranges. | `` |
 | `TINYAUTH_AUTH_USERS` | `--auth.users` | Comma-separated list of users (username:hashed_password). | `` |
 | `TINYAUTH_AUTH_USERSFILE` | `--auth.usersfile` | Path to the users file. | `` |
+| `TINYAUTH_AUTH_STANDALONE` | `--auth.standalone` | Run in standalone mode, do not set cookies for subdomains. | `false` |
 | `TINYAUTH_AUTH_SECURECOOKIE` | `--auth.securecookie` | Enable secure cookies. | `false` |
 | `TINYAUTH_AUTH_SESSIONEXPIRY` | `--auth.sessionexpiry` | Session expiry time in seconds. | `86400` |
 | `TINYAUTH_AUTH_SESSIONMAXLIFETIME` | `--auth.sessionmaxlifetime` | Maximum session lifetime in seconds. | `0` |


### PR DESCRIPTION
Documentation updates for feature from https://github.com/steveiliop56/tinyauth/pull/710

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated domain configuration guidance explaining conditional authentication cookie behavior based on standalone mode
  * Added documentation for new `TINYAUTH_AUTH_STANDALONE` configuration option controlling subdomain cookie behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->