### PR TITLE
refactor: move docs repo to org

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -40,7 +40,7 @@ export default defineConfig({
       },
       favicon: "/favicon.svg",
       editLink: {
-        baseUrl: "https://github.com/steveiliop56/tinyauth-docs/edit/main/",
+        baseUrl: "https://github.com/tinyauthapp/docs/edit/main/",
       },
       social: [
         {

--- a/src/content/docs/docs/reference/telemetry.mdx
+++ b/src/content/docs/docs/reference/telemetry.mdx
@@ -25,4 +25,4 @@ The data is sent to `https://api.tinyauth.app/v1/instances/hearbeat` every 12 ho
   prevent abuse of the API server.
 :::
 
-The telemetry server source is available on [GitHub](https://github.com/steveiliop56/tinyauth-analytics) licensed under the MIT license.
+The telemetry server source is available on [GitHub](https://github.com/tinyauthapp/analytics) licensed under the MIT license.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub repository links used in documentation edit links and telemetry reference documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->