### PR TITLE
docs: new user attributes config for oidc

### DIFF
--- a/src/content/docs/docs/guides/oidc.mdx
+++ b/src/content/docs/docs/guides/oidc.mdx
@@ -3,7 +3,7 @@ title: OIDC Server
 description: Use Tinyauth's OIDC server to authenticate applications.
 ---
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
+import { Tabs, TabItem } from "@astrojs/starlight/components";
 import CreateOidcClientTool from "../../../../components/create-oidc-client-tool.astro";
 
 In Tinyauth v5, a major milestone was the introduction of the OIDC server, which allows Tinyauth not only to use other identity providers but also to act as an identity provider itself. This means that Tinyauth can serve as a central authentication gateway for multiple applications, providing a single sign-on experience for users.
@@ -37,23 +37,39 @@ Supported scopes:
 - `profile`
 - `email`
 - `groups`
+- `phone`
+- `address`
 
 Supported claims:
 
 - `sub`
 - `name`
-- `email`
 - `preferred_username`
+- `email`
+- `email_verified`
 - `groups`
 - `updated_at`
-- `email_verified`
+- `given_name`
+- `family_name`
+- `middle_name`
+- `nickname`
+- `profile`
+- `picture`
+- `website`
+- `gender`
+- `birthdate`
+- `zoneinfo`
+- `locale`
+- `phone_number`
+- `phone_number_verified`
+- `address`
 
 Supported token endpoint authentication methods:
 
 - `client_secret_basic`
 - `client_secret_post`
 
-Due to the *mostly* stateless nature of Tinyauth, the user `sub` is based on the client ID and the username. This means that if the username or client ID changes, the `sub` will also change. This can cause issues with some OIDC clients that rely on the `sub` claim to identify the user consistently.
+Due to the _mostly_ stateless nature of Tinyauth, the user `sub` is based on the client ID and the username. This means that if the username or client ID changes, the `sub` will also change. This can cause issues with some OIDC clients that rely on the `sub` claim to identify the user consistently.
 
 :::note
 While no promises can be made, if you feel a required OpenID Connect feature is missing, please open an issue on [GitHub](https://github.com/steveiliop56/tinyauth/issues).
@@ -93,6 +109,7 @@ To create an OIDC client, use the `oidc create` command. For example:
     Client ID: client-id
     Client Secret: ta-client-secret
     ```
+
   </TabItem>
   <TabItem label="Binary">
     ```sh
@@ -106,6 +123,7 @@ To create an OIDC client, use the `oidc create` command. For example:
     Client ID: client-id
     Client Secret: ta-client-secret
     ```
+
   </TabItem>
   <TabItem label="Browser">
     <CreateOidcClientTool />
@@ -148,11 +166,11 @@ If you prefer, you can use `TINYAUTH_OIDC_CLIENTS_[NAME]_CLIENTSECRETFILE` (`--o
 
 Tinyauth exposes a well-known path at `/.well-known/openid-configuration` that apps can use to automatically discover the OIDC server configuration. If your app does not support discovery, you can configure it with the following endpoints:
 
-| Name                  | URL                                                  |
-| --------------------- | ---------------------------------------------------- |
-| Authorization Endpoint | `https://tinyauth.example.com/authorize`           |
-| Token Endpoint        | `https://tinyauth.example.com/api/oidc/token`       |
-| Userinfo Endpoint     | `https://tinyauth.example.com/api/oidc/userinfo`    |
+| Name                   | URL                                              |
+| ---------------------- | ------------------------------------------------ |
+| Authorization Endpoint | `https://tinyauth.example.com/authorize`         |
+| Token Endpoint         | `https://tinyauth.example.com/api/oidc/token`    |
+| Userinfo Endpoint      | `https://tinyauth.example.com/api/oidc/userinfo` |
 
 ## Usage
 
@@ -165,3 +183,44 @@ Tinyauth will preserve the OIDC request while logging in. Users authenticating v
 :::
 
 Tinyauth will pass user information from the OIDC or LDAP provider to the application while acting as a proxy. Enjoy!
+
+## User Attributes
+
+For local users, you can configure per-user OIDC attributes to populate profile, phone, and address claims. These are set via the `auth.userAttributes` config option, keyed by username.
+
+Example using environment variables:
+
+```sh
+TINYAUTH_AUTH_USERATTRIBUTES_ALICE_NAME=Alice Smith
+TINYAUTH_AUTH_USERATTRIBUTES_ALICE_EMAIL=alice@example.com
+TINYAUTH_AUTH_USERATTRIBUTES_ALICE_GIVENNAME=Alice
+TINYAUTH_AUTH_USERATTRIBUTES_ALICE_FAMILYNAME=Smith
+TINYAUTH_AUTH_USERATTRIBUTES_ALICE_PHONENUMBER=+1234567890
+TINYAUTH_AUTH_USERATTRIBUTES_ALICE_ZONEINFO=Europe/Athens
+TINYAUTH_AUTH_USERATTRIBUTES_ALICE_LOCALE=en-US
+```
+
+Or in YAML config:
+
+```yaml
+auth:
+  userAttributes:
+    alice:
+      name: Alice Smith
+      email: alice@example.com
+      givenName: Alice
+      familyName: Smith
+      phoneNumber: "+1234567890"
+      zoneinfo: Europe/Athens
+      locale: en-US
+      address:
+        streetAddress: 123 Main St
+        locality: Springfield
+        region: IL
+        postalCode: "62701"
+        country: US
+```
+
+When set, `name` and `email` attributes also override the display name and email used in the session cookie for that user.
+
+See the [Configuration Reference](/docs/reference/configuration) for the full list of available user attribute fields.

--- a/src/content/docs/docs/reference/configuration.mdx
+++ b/src/content/docs/docs/reference/configuration.mdx
@@ -6,155 +6,175 @@ description: Reference on Tinyauth's configuration.
 Tinyauth can be configured using environment variables or CLI flags. The table below provides a comprehensive list of configuration options.
 
 :::note
-  Configuration options with a `FILE_` equivalent (e.g., `TINYAUTH_AUTH_USERS`/`--auth.users` and
-  `TINYAUTH_AUTH_USERSFILE`/`--auth.usersfile`) allow the `FILE_` environment variable or CLI flag to be used as
-  an alternative.
+Configuration options with a `FILE_` equivalent (e.g., `TINYAUTH_AUTH_USERS`/`--auth.users` and
+`TINYAUTH_AUTH_USERSFILE`/`--auth.usersfile`) allow the `FILE_` environment variable or CLI flag to be used as
+an alternative.
 :::
 
 ## General Configuration
 
-| Environment | Flag | Description | Default |
-| - | - | - | - |
-| `TINYAUTH_APPURL` | `--appurl` | The base URL where the app is hosted. | `` |
+| Environment       | Flag       | Description                           | Default |
+| ----------------- | ---------- | ------------------------------------- | ------- |
+| `TINYAUTH_APPURL` | `--appurl` | The base URL where the app is hosted. | ``      |
 
 ## Database Configuration
 
-| Environment | Flag | Description | Default |
-| - | - | - | - |
+| Environment              | Flag              | Description                                    | Default         |
+| ------------------------ | ----------------- | ---------------------------------------------- | --------------- |
 | `TINYAUTH_DATABASE_PATH` | `--database.path` | The path to the database, including file name. | `./tinyauth.db` |
 
 ## Analytics Configuration
 
-| Environment | Flag | Description | Default |
-| - | - | - | - |
-| `TINYAUTH_ANALYTICS_ENABLED` | `--analytics.enabled` | Enable periodic version information collection. | `true` |
+| Environment                  | Flag                  | Description                                     | Default |
+| ---------------------------- | --------------------- | ----------------------------------------------- | ------- |
+| `TINYAUTH_ANALYTICS_ENABLED` | `--analytics.enabled` | Enable periodic version information collection. | `true`  |
 
 ## Resources Configuration
 
-| Environment | Flag | Description | Default |
-| - | - | - | - |
-| `TINYAUTH_RESOURCES_ENABLED` | `--resources.enabled` | Enable the resources server. | `true` |
-| `TINYAUTH_RESOURCES_PATH` | `--resources.path` | The directory where resources are stored. | `./resources` |
+| Environment                  | Flag                  | Description                               | Default       |
+| ---------------------------- | --------------------- | ----------------------------------------- | ------------- |
+| `TINYAUTH_RESOURCES_ENABLED` | `--resources.enabled` | Enable the resources server.              | `true`        |
+| `TINYAUTH_RESOURCES_PATH`    | `--resources.path`    | The directory where resources are stored. | `./resources` |
 
 ## Server Configuration
 
-| Environment | Flag | Description | Default |
-| - | - | - | - |
-| `TINYAUTH_SERVER_PORT` | `--server.port` | The port on which the server listens. | `3000` |
-| `TINYAUTH_SERVER_ADDRESS` | `--server.address` | The address on which the server listens. | `0.0.0.0` |
-| `TINYAUTH_SERVER_SOCKETPATH` | `--server.socketpath` | The path to the Unix socket. | `` |
+| Environment                  | Flag                  | Description                              | Default   |
+| ---------------------------- | --------------------- | ---------------------------------------- | --------- |
+| `TINYAUTH_SERVER_PORT`       | `--server.port`       | The port on which the server listens.    | `3000`    |
+| `TINYAUTH_SERVER_ADDRESS`    | `--server.address`    | The address on which the server listens. | `0.0.0.0` |
+| `TINYAUTH_SERVER_SOCKETPATH` | `--server.socketpath` | The path to the Unix socket.             | ``        |
 
 ## Authentication Configuration
 
-| Environment | Flag | Description | Default |
-| - | - | - | - |
-| `TINYAUTH_AUTH_IP_ALLOW` | `--auth.ip.allow` | List of allowed IPs or CIDR ranges. | `` |
-| `TINYAUTH_AUTH_IP_BLOCK` | `--auth.ip.block` | List of blocked IPs or CIDR ranges. | `` |
-| `TINYAUTH_AUTH_USERS` | `--auth.users` | Comma-separated list of users (username:hashed_password). | `` |
-| `TINYAUTH_AUTH_USERSFILE` | `--auth.usersfile` | Path to the users file. | `` |
-| `TINYAUTH_AUTH_SECURECOOKIE` | `--auth.securecookie` | Enable secure cookies. | `false` |
-| `TINYAUTH_AUTH_SESSIONEXPIRY` | `--auth.sessionexpiry` | Session expiry time in seconds. | `86400` |
-| `TINYAUTH_AUTH_SESSIONMAXLIFETIME` | `--auth.sessionmaxlifetime` | Maximum session lifetime in seconds. | `0` |
-| `TINYAUTH_AUTH_LOGINTIMEOUT` | `--auth.logintimeout` | Login timeout in seconds. | `300` |
-| `TINYAUTH_AUTH_LOGINMAXRETRIES` | `--auth.loginmaxretries` | Maximum login retries. | `3` |
-| `TINYAUTH_AUTH_TRUSTEDPROXIES` | `--auth.trustedproxies` | Comma-separated list of trusted proxy addresses. | `` |
+| Environment                                                     | Flag                                                     | Description                                               | Default |
+| --------------------------------------------------------------- | -------------------------------------------------------- | --------------------------------------------------------- | ------- |
+| `TINYAUTH_AUTH_IP_ALLOW`                                        | `--auth.ip.allow`                                        | List of allowed IPs or CIDR ranges.                       | ``      |
+| `TINYAUTH_AUTH_IP_BLOCK`                                        | `--auth.ip.block`                                        | List of blocked IPs or CIDR ranges.                       | ``      |
+| `TINYAUTH_AUTH_USERS`                                           | `--auth.users`                                           | Comma-separated list of users (username:hashed_password). | ``      |
+| `TINYAUTH_AUTH_USERSFILE`                                       | `--auth.usersfile`                                       | Path to the users file.                                   | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_NAME`                  | `--auth.userattributes.[username].name`                  | Full name of the user.                                    | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_GIVENNAME`             | `--auth.userattributes.[username].givenname`             | Given (first) name of the user.                           | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_FAMILYNAME`            | `--auth.userattributes.[username].familyname`            | Family (last) name of the user.                           | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_MIDDLENAME`            | `--auth.userattributes.[username].middlename`            | Middle name of the user.                                  | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_NICKNAME`              | `--auth.userattributes.[username].nickname`              | Nickname of the user.                                     | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_PROFILE`               | `--auth.userattributes.[username].profile`               | URL of the user's profile page.                           | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_PICTURE`               | `--auth.userattributes.[username].picture`               | URL of the user's profile picture.                        | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_WEBSITE`               | `--auth.userattributes.[username].website`               | URL of the user's website.                                | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_EMAIL`                 | `--auth.userattributes.[username].email`                 | Email address of the user.                                | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_GENDER`                | `--auth.userattributes.[username].gender`                | Gender of the user.                                       | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_BIRTHDATE`             | `--auth.userattributes.[username].birthdate`             | Birthdate of the user (YYYY-MM-DD).                       | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_ZONEINFO`              | `--auth.userattributes.[username].zoneinfo`              | Time zone of the user (e.g. Europe/Athens).               | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_LOCALE`                | `--auth.userattributes.[username].locale`                | Locale of the user (e.g. en-US).                          | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_PHONENUMBER`           | `--auth.userattributes.[username].phonenumber`           | Phone number of the user.                                 | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_ADDRESS_FORMATTED`     | `--auth.userattributes.[username].address.formatted`     | Full mailing address, formatted for display.              | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_ADDRESS_STREETADDRESS` | `--auth.userattributes.[username].address.streetaddress` | Street address.                                           | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_ADDRESS_LOCALITY`      | `--auth.userattributes.[username].address.locality`      | City or locality.                                         | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_ADDRESS_REGION`        | `--auth.userattributes.[username].address.region`        | State, province, or region.                               | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_ADDRESS_POSTALCODE`    | `--auth.userattributes.[username].address.postalcode`    | Zip or postal code.                                       | ``      |
+| `TINYAUTH_AUTH_USERATTRIBUTES_[USERNAME]_ADDRESS_COUNTRY`       | `--auth.userattributes.[username].address.country`       | Country.                                                  | ``      |
+| `TINYAUTH_AUTH_SECURECOOKIE`                                    | `--auth.securecookie`                                    | Enable secure cookies.                                    | `false` |
+| `TINYAUTH_AUTH_SESSIONEXPIRY`                                   | `--auth.sessionexpiry`                                   | Session expiry time in seconds.                           | `86400` |
+| `TINYAUTH_AUTH_SESSIONMAXLIFETIME`                              | `--auth.sessionmaxlifetime`                              | Maximum session lifetime in seconds.                      | `0`     |
+| `TINYAUTH_AUTH_LOGINTIMEOUT`                                    | `--auth.logintimeout`                                    | Login timeout in seconds.                                 | `300`   |
+| `TINYAUTH_AUTH_LOGINMAXRETRIES`                                 | `--auth.loginmaxretries`                                 | Maximum login retries.                                    | `3`     |
+| `TINYAUTH_AUTH_TRUSTEDPROXIES`                                  | `--auth.trustedproxies`                                  | Comma-separated list of trusted proxy addresses.          | ``      |
 
 ## ACLs Configuration
 
-| Environment | Flag | Description | Default |
-| - | - | - | - |
-| `TINYAUTH_APPS_[NAME]_CONFIG_DOMAIN` | `--apps.[name].config.domain` | The domain of the app. | `` |
-| `TINYAUTH_APPS_[NAME]_USERS_ALLOW` | `--apps.[name].users.allow` | Comma-separated list of allowed users. | `` |
-| `TINYAUTH_APPS_[NAME]_USERS_BLOCK` | `--apps.[name].users.block` | Comma-separated list of blocked users. | `` |
-| `TINYAUTH_APPS_[NAME]_OAUTH_WHITELIST` | `--apps.[name].oauth.whitelist` | Comma-separated list of allowed OAuth groups. | `` |
-| `TINYAUTH_APPS_[NAME]_OAUTH_GROUPS` | `--apps.[name].oauth.groups` | Comma-separated list of required OAuth groups. | `` |
-| `TINYAUTH_APPS_[NAME]_IP_ALLOW` | `--apps.[name].ip.allow` | List of allowed IPs or CIDR ranges. | `` |
-| `TINYAUTH_APPS_[NAME]_IP_BLOCK` | `--apps.[name].ip.block` | List of blocked IPs or CIDR ranges. | `` |
-| `TINYAUTH_APPS_[NAME]_IP_BYPASS` | `--apps.[name].ip.bypass` | List of IPs or CIDR ranges that bypass authentication. | `` |
-| `TINYAUTH_APPS_[NAME]_RESPONSE_HEADERS` | `--apps.[name].response.headers` | Custom headers to add to the response. | `` |
-| `TINYAUTH_APPS_[NAME]_RESPONSE_BASICAUTH_USERNAME` | `--apps.[name].response.basicauth.username` | Basic auth username. | `` |
-| `TINYAUTH_APPS_[NAME]_RESPONSE_BASICAUTH_PASSWORD` | `--apps.[name].response.basicauth.password` | Basic auth password. | `` |
-| `TINYAUTH_APPS_[NAME]_RESPONSE_BASICAUTH_PASSWORDFILE` | `--apps.[name].response.basicauth.passwordfile` | Path to the file containing the basic auth password. | `` |
-| `TINYAUTH_APPS_[NAME]_PATH_ALLOW` | `--apps.[name].path.allow` | Comma-separated list of allowed paths. | `` |
-| `TINYAUTH_APPS_[NAME]_PATH_BLOCK` | `--apps.[name].path.block` | Comma-separated list of blocked paths. | `` |
-| `TINYAUTH_APPS_[NAME]_LDAP_GROUPS` | `--apps.[name].ldap.groups` | Comma-separated list of required LDAP groups. | `` |
+| Environment                                            | Flag                                            | Description                                            | Default |
+| ------------------------------------------------------ | ----------------------------------------------- | ------------------------------------------------------ | ------- |
+| `TINYAUTH_APPS_[NAME]_CONFIG_DOMAIN`                   | `--apps.[name].config.domain`                   | The domain of the app.                                 | ``      |
+| `TINYAUTH_APPS_[NAME]_USERS_ALLOW`                     | `--apps.[name].users.allow`                     | Comma-separated list of allowed users.                 | ``      |
+| `TINYAUTH_APPS_[NAME]_USERS_BLOCK`                     | `--apps.[name].users.block`                     | Comma-separated list of blocked users.                 | ``      |
+| `TINYAUTH_APPS_[NAME]_OAUTH_WHITELIST`                 | `--apps.[name].oauth.whitelist`                 | Comma-separated list of allowed OAuth groups.          | ``      |
+| `TINYAUTH_APPS_[NAME]_OAUTH_GROUPS`                    | `--apps.[name].oauth.groups`                    | Comma-separated list of required OAuth groups.         | ``      |
+| `TINYAUTH_APPS_[NAME]_IP_ALLOW`                        | `--apps.[name].ip.allow`                        | List of allowed IPs or CIDR ranges.                    | ``      |
+| `TINYAUTH_APPS_[NAME]_IP_BLOCK`                        | `--apps.[name].ip.block`                        | List of blocked IPs or CIDR ranges.                    | ``      |
+| `TINYAUTH_APPS_[NAME]_IP_BYPASS`                       | `--apps.[name].ip.bypass`                       | List of IPs or CIDR ranges that bypass authentication. | ``      |
+| `TINYAUTH_APPS_[NAME]_RESPONSE_HEADERS`                | `--apps.[name].response.headers`                | Custom headers to add to the response.                 | ``      |
+| `TINYAUTH_APPS_[NAME]_RESPONSE_BASICAUTH_USERNAME`     | `--apps.[name].response.basicauth.username`     | Basic auth username.                                   | ``      |
+| `TINYAUTH_APPS_[NAME]_RESPONSE_BASICAUTH_PASSWORD`     | `--apps.[name].response.basicauth.password`     | Basic auth password.                                   | ``      |
+| `TINYAUTH_APPS_[NAME]_RESPONSE_BASICAUTH_PASSWORDFILE` | `--apps.[name].response.basicauth.passwordfile` | Path to the file containing the basic auth password.   | ``      |
+| `TINYAUTH_APPS_[NAME]_PATH_ALLOW`                      | `--apps.[name].path.allow`                      | Comma-separated list of allowed paths.                 | ``      |
+| `TINYAUTH_APPS_[NAME]_PATH_BLOCK`                      | `--apps.[name].path.block`                      | Comma-separated list of blocked paths.                 | ``      |
+| `TINYAUTH_APPS_[NAME]_LDAP_GROUPS`                     | `--apps.[name].ldap.groups`                     | Comma-separated list of required LDAP groups.          | ``      |
 
 ## OAuth Configuration
 
-| Environment | Flag | Description | Default |
-| - | - | - | - |
-| `TINYAUTH_OAUTH_WHITELIST` | `--oauth.whitelist` | Comma-separated list of allowed OAuth domains. | `` |
-| `TINYAUTH_OAUTH_AUTOREDIRECT` | `--oauth.autoredirect` | The OAuth provider to use for automatic redirection. | `` |
-| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_CLIENTID` | `--oauth.providers.[name].clientid` | OAuth client ID. | `` |
-| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_CLIENTSECRET` | `--oauth.providers.[name].clientsecret` | OAuth client secret. | `` |
-| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_CLIENTSECRETFILE` | `--oauth.providers.[name].clientsecretfile` | Path to the file containing the OAuth client secret. | `` |
-| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_SCOPES` | `--oauth.providers.[name].scopes` | OAuth scopes. | `` |
-| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_REDIRECTURL` | `--oauth.providers.[name].redirecturl` | OAuth redirect URL. | `` |
-| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_AUTHURL` | `--oauth.providers.[name].authurl` | OAuth authorization URL. | `` |
-| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_TOKENURL` | `--oauth.providers.[name].tokenurl` | OAuth token URL. | `` |
-| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_USERINFOURL` | `--oauth.providers.[name].userinfourl` | OAuth userinfo URL. | `` |
-| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_INSECURE` | `--oauth.providers.[name].insecure` | Allow insecure OAuth connections. | `false` |
-| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_NAME` | `--oauth.providers.[name].name` | Provider name in UI. | `` |
+| Environment                                        | Flag                                        | Description                                          | Default |
+| -------------------------------------------------- | ------------------------------------------- | ---------------------------------------------------- | ------- |
+| `TINYAUTH_OAUTH_WHITELIST`                         | `--oauth.whitelist`                         | Comma-separated list of allowed OAuth domains.       | ``      |
+| `TINYAUTH_OAUTH_AUTOREDIRECT`                      | `--oauth.autoredirect`                      | The OAuth provider to use for automatic redirection. | ``      |
+| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_CLIENTID`         | `--oauth.providers.[name].clientid`         | OAuth client ID.                                     | ``      |
+| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_CLIENTSECRET`     | `--oauth.providers.[name].clientsecret`     | OAuth client secret.                                 | ``      |
+| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_CLIENTSECRETFILE` | `--oauth.providers.[name].clientsecretfile` | Path to the file containing the OAuth client secret. | ``      |
+| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_SCOPES`           | `--oauth.providers.[name].scopes`           | OAuth scopes.                                        | ``      |
+| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_REDIRECTURL`      | `--oauth.providers.[name].redirecturl`      | OAuth redirect URL.                                  | ``      |
+| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_AUTHURL`          | `--oauth.providers.[name].authurl`          | OAuth authorization URL.                             | ``      |
+| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_TOKENURL`         | `--oauth.providers.[name].tokenurl`         | OAuth token URL.                                     | ``      |
+| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_USERINFOURL`      | `--oauth.providers.[name].userinfourl`      | OAuth userinfo URL.                                  | ``      |
+| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_INSECURE`         | `--oauth.providers.[name].insecure`         | Allow insecure OAuth connections.                    | `false` |
+| `TINYAUTH_OAUTH_PROVIDERS_[NAME]_NAME`             | `--oauth.providers.[name].name`             | Provider name in UI.                                 | ``      |
 
 :::note
-  Using `google` or `github` as provider IDs, triggers automatic filling of the
-  required information (e.g., auth URLs, scopes). You will only have to
-  provide the client ID and secret.
+Using `google` or `github` as provider IDs, triggers automatic filling of the
+required information (e.g., auth URLs, scopes). You will only have to
+provide the client ID and secret.
 :::
 
 ## OIDC Configuration
 
-| Environment | Flag | Description | Default |
-| - | - | - | - |
-| `TINYAUTH_OIDC_PRIVATEKEYPATH` | `--oidc.privatekeypath` | Path to the private key file, including file name. | `./tinyauth_oidc_key` |
-| `TINYAUTH_OIDC_PUBLICKEYPATH` | `--oidc.publickeypath` | Path to the public key file, including file name. | `./tinyauth_oidc_key.pub` |
-| `TINYAUTH_OIDC_CLIENTS_[NAME]_CLIENTID` | `--oidc.clients.[name].clientid` | OIDC client ID. | `` |
-| `TINYAUTH_OIDC_CLIENTS_[NAME]_CLIENTSECRET` | `--oidc.clients.[name].clientsecret` | OIDC client secret. | `` |
-| `TINYAUTH_OIDC_CLIENTS_[NAME]_CLIENTSECRETFILE` | `--oidc.clients.[name].clientsecretfile` | Path to the file containing the OIDC client secret. | `` |
-| `TINYAUTH_OIDC_CLIENTS_[NAME]_TRUSTEDREDIRECTURIS` | `--oidc.clients.[name].trustedredirecturis` | List of trusted redirect URIs. | `` |
-| `TINYAUTH_OIDC_CLIENTS_[NAME]_NAME` | `--oidc.clients.[name].name` | Client name in UI. | `` |
+| Environment                                        | Flag                                        | Description                                         | Default                   |
+| -------------------------------------------------- | ------------------------------------------- | --------------------------------------------------- | ------------------------- |
+| `TINYAUTH_OIDC_PRIVATEKEYPATH`                     | `--oidc.privatekeypath`                     | Path to the private key file, including file name.  | `./tinyauth_oidc_key`     |
+| `TINYAUTH_OIDC_PUBLICKEYPATH`                      | `--oidc.publickeypath`                      | Path to the public key file, including file name.   | `./tinyauth_oidc_key.pub` |
+| `TINYAUTH_OIDC_CLIENTS_[NAME]_CLIENTID`            | `--oidc.clients.[name].clientid`            | OIDC client ID.                                     | ``                        |
+| `TINYAUTH_OIDC_CLIENTS_[NAME]_CLIENTSECRET`        | `--oidc.clients.[name].clientsecret`        | OIDC client secret.                                 | ``                        |
+| `TINYAUTH_OIDC_CLIENTS_[NAME]_CLIENTSECRETFILE`    | `--oidc.clients.[name].clientsecretfile`    | Path to the file containing the OIDC client secret. | ``                        |
+| `TINYAUTH_OIDC_CLIENTS_[NAME]_TRUSTEDREDIRECTURIS` | `--oidc.clients.[name].trustedredirecturis` | List of trusted redirect URIs.                      | ``                        |
+| `TINYAUTH_OIDC_CLIENTS_[NAME]_NAME`                | `--oidc.clients.[name].name`                | Client name in UI.                                  | ``                        |
 
 ## UI Configuration
 
-| Environment | Flag | Description | Default |
-| - | - | - | - |
-| `TINYAUTH_UI_TITLE` | `--ui.title` | The title of the UI. | `Tinyauth` |
+| Environment                         | Flag                         | Description                                    | Default                                                       |
+| ----------------------------------- | ---------------------------- | ---------------------------------------------- | ------------------------------------------------------------- |
+| `TINYAUTH_UI_TITLE`                 | `--ui.title`                 | The title of the UI.                           | `Tinyauth`                                                    |
 | `TINYAUTH_UI_FORGOTPASSWORDMESSAGE` | `--ui.forgotpasswordmessage` | Message displayed on the forgot password page. | `You can change your password by changing the configuration.` |
-| `TINYAUTH_UI_BACKGROUNDIMAGE` | `--ui.backgroundimage` | Path to the background image. | `/background.jpg` |
-| `TINYAUTH_UI_WARNINGSENABLED` | `--ui.warningsenabled` | Enable UI warnings. | `true` |
+| `TINYAUTH_UI_BACKGROUNDIMAGE`       | `--ui.backgroundimage`       | Path to the background image.                  | `/background.jpg`                                             |
+| `TINYAUTH_UI_WARNINGSENABLED`       | `--ui.warningsenabled`       | Enable UI warnings.                            | `true`                                                        |
 
 ## LDAP Configuration
 
-| Environment | Flag | Description | Default |
-| - | - | - | - |
-| `TINYAUTH_LDAP_ADDRESS` | `--ldap.address` | LDAP server address. | `` |
-| `TINYAUTH_LDAP_BINDDN` | `--ldap.binddn` | Bind DN for LDAP authentication. | `` |
-| `TINYAUTH_LDAP_BINDPASSWORD` | `--ldap.bindpassword` | Bind password for LDAP authentication. | `` |
-| `TINYAUTH_LDAP_BASEDN` | `--ldap.basedn` | Base DN for LDAP searches. | `` |
-| `TINYAUTH_LDAP_INSECURE` | `--ldap.insecure` | Allow insecure LDAP connections. | `false` |
-| `TINYAUTH_LDAP_SEARCHFILTER` | `--ldap.searchfilter` | LDAP search filter. | `(uid=%s)` |
-| `TINYAUTH_LDAP_AUTHCERT` | `--ldap.authcert` | Certificate for mTLS authentication. | `` |
-| `TINYAUTH_LDAP_AUTHKEY` | `--ldap.authkey` | Certificate key for mTLS authentication. | `` |
-| `TINYAUTH_LDAP_GROUPCACHETTL` | `--ldap.groupcachettl` | Cache duration for LDAP group membership in seconds. | `900` |
+| Environment                   | Flag                   | Description                                          | Default    |
+| ----------------------------- | ---------------------- | ---------------------------------------------------- | ---------- |
+| `TINYAUTH_LDAP_ADDRESS`       | `--ldap.address`       | LDAP server address.                                 | ``         |
+| `TINYAUTH_LDAP_BINDDN`        | `--ldap.binddn`        | Bind DN for LDAP authentication.                     | ``         |
+| `TINYAUTH_LDAP_BINDPASSWORD`  | `--ldap.bindpassword`  | Bind password for LDAP authentication.               | ``         |
+| `TINYAUTH_LDAP_BASEDN`        | `--ldap.basedn`        | Base DN for LDAP searches.                           | ``         |
+| `TINYAUTH_LDAP_INSECURE`      | `--ldap.insecure`      | Allow insecure LDAP connections.                     | `false`    |
+| `TINYAUTH_LDAP_SEARCHFILTER`  | `--ldap.searchfilter`  | LDAP search filter.                                  | `(uid=%s)` |
+| `TINYAUTH_LDAP_AUTHCERT`      | `--ldap.authcert`      | Certificate for mTLS authentication.                 | ``         |
+| `TINYAUTH_LDAP_AUTHKEY`       | `--ldap.authkey`       | Certificate key for mTLS authentication.             | ``         |
+| `TINYAUTH_LDAP_GROUPCACHETTL` | `--ldap.groupcachettl` | Cache duration for LDAP group membership in seconds. | `900`      |
 
 :::note
-  For Windows LDAP, use the following search filter: `(&(sAMAccountName=%s))`.
+For Windows LDAP, use the following search filter: `(&(sAMAccountName=%s))`.
 :::
 
 ## Logging Configuration
 
-| Environment | Flag | Description | Default |
-| - | - | - | - |
-| `TINYAUTH_LOG_LEVEL` | `--log.level` | Log level (trace, debug, info, warn, error). | `info` |
-| `TINYAUTH_LOG_JSON` | `--log.json` | Enable JSON formatted logs. | `false` |
-| `TINYAUTH_LOG_STREAMS_HTTP_ENABLED` | `--log.streams.http.enabled` | Enable this log stream. | `true` |
-| `TINYAUTH_LOG_STREAMS_HTTP_LEVEL` | `--log.streams.http.level` | Log level for this stream. Use global if empty. | `` |
-| `TINYAUTH_LOG_STREAMS_APP_ENABLED` | `--log.streams.app.enabled` | Enable this log stream. | `true` |
-| `TINYAUTH_LOG_STREAMS_APP_LEVEL` | `--log.streams.app.level` | Log level for this stream. Use global if empty. | `` |
-| `TINYAUTH_LOG_STREAMS_AUDIT_ENABLED` | `--log.streams.audit.enabled` | Enable this log stream. | `false` |
-| `TINYAUTH_LOG_STREAMS_AUDIT_LEVEL` | `--log.streams.audit.level` | Log level for this stream. Use global if empty. | `` |
+| Environment                          | Flag                          | Description                                     | Default |
+| ------------------------------------ | ----------------------------- | ----------------------------------------------- | ------- |
+| `TINYAUTH_LOG_LEVEL`                 | `--log.level`                 | Log level (trace, debug, info, warn, error).    | `info`  |
+| `TINYAUTH_LOG_JSON`                  | `--log.json`                  | Enable JSON formatted logs.                     | `false` |
+| `TINYAUTH_LOG_STREAMS_HTTP_ENABLED`  | `--log.streams.http.enabled`  | Enable this log stream.                         | `true`  |
+| `TINYAUTH_LOG_STREAMS_HTTP_LEVEL`    | `--log.streams.http.level`    | Log level for this stream. Use global if empty. | ``      |
+| `TINYAUTH_LOG_STREAMS_APP_ENABLED`   | `--log.streams.app.enabled`   | Enable this log stream.                         | `true`  |
+| `TINYAUTH_LOG_STREAMS_APP_LEVEL`     | `--log.streams.app.level`     | Log level for this stream. Use global if empty. | ``      |
+| `TINYAUTH_LOG_STREAMS_AUDIT_ENABLED` | `--log.streams.audit.enabled` | Enable this log stream.                         | `false` |
+| `TINYAUTH_LOG_STREAMS_AUDIT_LEVEL`   | `--log.streams.audit.level`   | Log level for this stream. Use global if empty. | ``      |
 
 :::caution
-  The `trace` log level will log sensitive information such as usernames, emails
-  and access controls. Use with caution.
+The `trace` log level will log sensitive information such as usernames, emails
+and access controls. Use with caution.
 :::


### PR DESCRIPTION
prettier has formatted the tables, that's why the diff is so large.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded OIDC guide with additional scope and claim coverage, including phone and address scopes
  * New User Attributes section documenting per-user attribute configuration via environment variables and YAML
  * Enhanced Configuration reference with comprehensive userAttributes options (name, email, profile, phone, address, and identity attributes)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->