### PR TITLE
Add a basic guide for generic OAuth providers.

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -89,6 +89,10 @@ export default defineConfig({
               slug: "docs/guides/pocket-id",
             },
             {
+              label: "Other OAuth Providers",
+              slug: "docs/guides/generic-oauth",
+            },
+            {
               label: "LDAP",
               slug: "docs/guides/ldap",
             },

--- a/src/content/docs/docs/guides/generic-oauth
+++ b/src/content/docs/docs/guides/generic-oauth
@@ -1,0 +1,63 @@
+---
+title: Other OAuth Providers
+description: Use a OAuth provider not already listed as an OAuth provider in Tinyauth.
+---
+
+## Requirements
+
+A working OAuth provider that is OpenID Connect compliant and a good understanding of how to use your provider.
+This guide will not go into specifics since each OAuth provider is different.
+
+:::note
+  Your OAuth provider will need to have emails linked to each account.
+:::
+
+## Key info
+
+We need to know the urls that Tinyauth and your OAuth provider is accessible at.
+This guide is using placeholders for this info.
+`<tinyauth_url>` for Tinyauth and `<provider_url>` for the OAuth provider.
+Change these values out with your own when implementing.
+
+You will also need to know your providers endoints for authorization_endpoint, token_endpoint, and userinfo_endpoint.
+If your provider has a `.well-known/openid-configuration` url then that would provide this info. Otherwise read your providers docs.
+These endpoints are also using placeholders in this guide.
+
+We also need the client id and client secret. These use the `<client_id>` and `<client_secret> placeholders respectively.
+
+## Configuring the OAuth provider
+
+Create a new client in your OAuth provider. This client will need a callback/redirect url of `https://<tinyauth_url>/api/oauth/callback/generic`.
+You will need the client id and client secret from your provider.
+
+## Configuring Tinyauth
+
+Add the following entries to your tinyauth service's environment section substituting placeholders:
+```yaml
+services:
+  tinyauth:
+    environment:
+      - TINYAUTH_OAUTH_PROVIDERS_GENERIC_CLIENTID=<client_id>
+      - TINYAUTH_OAUTH_PROVIDERS_GENERIC_CLIENTSECRET=<client_secret>
+      - TINYAUTH_OAUTH_PROVIDERS_GENERIC_AUTHURL=<authorization_endpoint>
+      - TINYAUTH_OAUTH_PROVIDERS_GENERIC_TOKENURL=<token_endpoint>
+      - TINYAUTH_OAUTH_PROVIDERS_GENERIC_USERINFOURL=<userinfo_endpoint>
+      - TINYAUTH_OAUTH_PROVIDERS_GENERIC_SCOPES=openid,email,profile
+      - TINYAUTH_OAUTH_PROVIDERS_GENERIC_REDIRECTURL=https://<tinyauth_url>/api/oauth/callback/generic
+      - TINYAUTH_OAUTH_PROVIDERS_GENERIC_NAME=<Any name you want. This will display as a button in Tinyauth for your provider>
+      - TINYAUTH_OAUTH_PROVIDERS_GENERIC_INSECURE=false # Change to true if your provider is using self signed certificates
+```
+
+:::caution
+  OAuth alone does not guarantee security. By default, any OAuth account can
+  log in as a normal user. To restrict access, use the `TINYAUTH_OAUTH_WHITELIST`
+  environment variable to allow specific email addresses. Refer to the
+  [configuration](/docs/reference/configuration) page for details.
+:::
+
+:::note
+  With OAuth enabled, the `TINYAUTH_AUTH_USERS` or `TINYAUTH_AUTH_USERSFILE` environment variable can be
+  removed to allow login exclusively through the OAuth provider.
+:::
+
+Restart Tinyauth to apply the changes. The login screen will now include an option to log in with your OAuth provider.

--- a/src/content/docs/docs/guides/generic-oauth.mdx
+++ b/src/content/docs/docs/guides/generic-oauth.mdx
@@ -19,7 +19,7 @@ This guide is using placeholders for this info.
 `<tinyauth_url>` for Tinyauth and `<provider_url>` for the OAuth provider.
 Change these values out with your own when implementing.
 
-You will also need to know your providers endoints for authorization_endpoint, token_endpoint, and userinfo_endpoint.
+You will also need to know your providers endpoints for authorization_endpoint, token_endpoint, and userinfo_endpoint.
 If your provider has a `.well-known/openid-configuration` url then that would provide this info. Otherwise read your providers docs.
 These endpoints are also using placeholders in this guide.
 

--- a/src/content/docs/docs/guides/generic-oauth.mdx
+++ b/src/content/docs/docs/guides/generic-oauth.mdx
@@ -1,6 +1,6 @@
 ---
 title: Other OAuth Providers
-description: Use a OAuth provider not already listed as an OAuth provider in Tinyauth.
+description: Use an OAuth provider not already listed as an OAuth provider in Tinyauth.
 ---
 
 ## Requirements


### PR DESCRIPTION
Closes https://github.com/tinyauthapp/tinyauth/issues/921

I was going to run the Astro Documentation and validate everything, but it failed during the install of sharp on my machine. :(

I suspect that there is some cleanup to be done or something that I missed. Thanks for making such a great project! I have only been playing around with it for a half hour or so, but it has shown great potential. I cannot wait to use it to replace my three dozen or so basic http authentications.

Error from when attempting to run `npm install`:
```
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'tinyauth-docs@0.0.1',
npm warn EBADENGINE   required: { node: 'v25.5.0' },
npm warn EBADENGINE   current: { node: 'v26.2.0', npm: '11.14.1' }
npm warn EBADENGINE }
npm error code 1
npm error path /home/user/tinyauthdocs/node_modules/sharp
npm error command failed
npm error command sh -c node install/check.js || npm run build
npm error > sharp@0.34.5 build
npm error > node install/build.js
npm error
npm error sharp: Attempting to build from source via node-gyp
npm error sharp: See https://sharp.pixelplumbing.com/install#building-from-source
npm error sharp: Please add node-addon-api to your dependencies
npm error A complete log of this run can be found in: /home/<redacted>/.npm/_logs/2026-06-05T17_03_03_182Z-debug-0.log
```