### PR TITLE
Update Docker image name

### DIFF
--- a/src/content/docs/docs/community/caddy.mdx
+++ b/src/content/docs/docs/community/caddy.mdx
@@ -58,7 +58,7 @@ Add Tinyauth and place it behind Caddy with the `caddy` and `caddy.reverse_proxy
 ```yaml
 services:
   tinyauth:
-    image: ghcr.io/steveiliop56/tinyauth:v5
+    image: ghcr.io/tinyauthapp/tinyauth:v5
     restart: unless-stopped
     environment:
       - TINYAUTH_APPURL=http://auth.example.com
@@ -117,7 +117,7 @@ services:
       caddy.forward_auth.copy_headers: Remote-User Remote-Name Remote-Email Remote-Groups # optional when you want to make headers available to your service
 
   tinyauth:
-    image: ghcr.io/steveiliop56/tinyauth:v5
+    image: ghcr.io/tinyauthapp/tinyauth:v5
     restart: unless-stopped
     environment:
       - TINYAUTH_APPURL=http://auth.example.com

--- a/src/content/docs/docs/community/kubernetes.mdx
+++ b/src/content/docs/docs/community/kubernetes.mdx
@@ -53,7 +53,7 @@ spec:
     spec:
       containers:
         - name: tinyauth
-          image: ghcr.io/steveiliop56/tinyauth:v5
+          image: ghcr.io/tinyauthapp/tinyauth:v5
           ports:
             - containerPort: 3000
           env:

--- a/src/content/docs/docs/getting-started.mdx
+++ b/src/content/docs/docs/getting-started.mdx
@@ -46,7 +46,7 @@ The following CLI command facilitates user creation:
 <Tabs>
   <TabItem label="Docker">
     ```sh
-    docker run -i -t --rm ghcr.io/steveiliop56/tinyauth:v5 user create --interactive
+    docker run -i -t --rm ghcr.io/tinyauthapp/tinyauth:v5 user create --interactive
     ```
 
     This command prompts for a username and password, generating the required user configuration. Additional details are available in the CLI [reference](/docs/reference/cli#create-user-command).
@@ -97,7 +97,7 @@ The following `docker-compose.yml` configuration deploys Tinyauth:
 
 ```yaml title="docker-compose.yml"
 tinyauth:
-  image: ghcr.io/steveiliop56/tinyauth:v5
+  image: ghcr.io/tinyauthapp/tinyauth:v5
   restart: unless-stopped
   environment:
     - TINYAUTH_APPURL=https://tinyauth.example.com
@@ -147,7 +147,7 @@ services:
       traefik.http.routers.whoami.middlewares: tinyauth
 
   tinyauth:
-    image: ghcr.io/steveiliop56/tinyauth:v5
+    image: ghcr.io/tinyauthapp/tinyauth:v5
     restart: unless-stopped
     environment:
       - TINYAUTH_APPURL=https://tinyauth.example.com

--- a/src/content/docs/docs/guides/nginx-proxy-manager.mdx
+++ b/src/content/docs/docs/guides/nginx-proxy-manager.mdx
@@ -32,7 +32,7 @@ services:
     restart: unless-stopped
 
   tinyauth:
-    image: ghcr.io/steveiliop56/tinyauth:v5
+    image: ghcr.io/tinyauthapp/tinyauth:v5
     restart: unless-stopped
     environment:
       - TINYAUTH_APPURL=http://tinyauth.example.com

--- a/src/content/docs/docs/guides/oidc.mdx
+++ b/src/content/docs/docs/guides/oidc.mdx
@@ -116,7 +116,7 @@ To create an OIDC client, use the `oidc create` command. For example:
 <Tabs>
   <TabItem label="Docker">
     ```sh
-    docker run -i -t --rm ghcr.io/steveiliop56/tinyauth:v5 oidc create myapp
+    docker run -i -t --rm ghcr.io/tinyauthapp/tinyauth:v5 oidc create myapp
     ```
 
     This will produce output similar to:

--- a/src/content/docs/docs/guides/totp.mdx
+++ b/src/content/docs/docs/guides/totp.mdx
@@ -15,7 +15,7 @@ A TOTP secret must first be generated. This requires the current `username:hash`
 <Tabs>
   <TabItem label="Docker">
     ```sh
-    docker run -i -t --rm ghcr.io/steveiliop56/tinyauth:v5 totp generate --interactive
+    docker run -i -t --rm ghcr.io/tinyauthapp/tinyauth:v5 totp generate --interactive
     ```
 
     The command prompts for the user and generates a QR code to scan with an authenticator app. Once added, copy the newly generated user (displayed after the `user=` log message) and include it in the Tinyauth user list. Restart Tinyauth to apply changes.
@@ -49,7 +49,7 @@ If you want to ensure that the user is configured correctly, you can use the fol
 <Tabs>
   <TabItem label="Docker">
     ```sh
-    docker run -i -t --rm ghcr.io/steveiliop56/tinyauth:v5 user verify --interactive
+    docker run -i -t --rm ghcr.io/tinyauthapp/tinyauth:v5 user verify --interactive
     ```
   </TabItem>
   <TabItem label="Binary">

--- a/src/content/docs/docs/integrations/beszel.mdx
+++ b/src/content/docs/docs/integrations/beszel.mdx
@@ -24,7 +24,7 @@ To begin with, we need to generate a client ID and secret in Tinyauth for Beszel
 <Tabs>
     <TabItem label="Docker">
         ```sh
-        docker run -i -t --rm ghcr.io/steveiliop56/tinyauth:v5 oidc create beszel
+        docker run -i -t --rm ghcr.io/tinyauthapp/tinyauth:v5 oidc create beszel
         ```
     </TabItem>
     <TabItem label="Binary">

--- a/src/content/docs/docs/integrations/immich.mdx
+++ b/src/content/docs/docs/integrations/immich.mdx
@@ -25,7 +25,7 @@ First, generate an OIDC client for Immich in Tinyauth:
 <Tabs>
   <TabItem label="Docker">
     ```sh
-    docker run -i -t --rm ghcr.io/steveiliop56/tinyauth:v5 oidc create immich
+    docker run -i -t --rm ghcr.io/tinyauthapp/tinyauth:v5 oidc create immich
     ```
   </TabItem>
   <TabItem label="Binary">

--- a/src/content/docs/docs/integrations/tailscale.mdx
+++ b/src/content/docs/docs/integrations/tailscale.mdx
@@ -35,7 +35,7 @@ To begin with, we need to generate a client ID and secret in Tinyauth for Tailsc
 <Tabs>
   <TabItem label="Docker">
     ```sh
-    docker run -i -t --rm ghcr.io/steveiliop56/tinyauth:v5 oidc create tailscale
+    docker run -i -t --rm ghcr.io/tinyauthapp/tinyauth:v5 oidc create tailscale
     ```
   </TabItem>
   <TabItem label="Binary">

--- a/src/content/docs/docs/integrations/zerobyte.mdx
+++ b/src/content/docs/docs/integrations/zerobyte.mdx
@@ -25,7 +25,7 @@ To begin with, we need to generate a client ID and secret in Tinyauth for Zeroby
 <Tabs>
   <TabItem label="Docker">
     ```sh
-    docker run -i -t --rm ghcr.io/steveiliop56/tinyauth:v5 oidc create zerobyte
+    docker run -i -t --rm ghcr.io/tinyauthapp/tinyauth:v5 oidc create zerobyte
     ```
   </TabItem>
   <TabItem label="Binary">

--- a/src/content/docs/docs/reference/cli.mdx
+++ b/src/content/docs/docs/reference/cli.mdx
@@ -18,7 +18,7 @@ All commands can be run from the standalone Tinyauth binary:
 Alternatively, when running the app through Docker:
 
 ```sh
-docker run -i -t --rm ghcr.io/steveiliop56/tinyauth:v5 [options]
+docker run -i -t --rm ghcr.io/tinyauthapp/tinyauth:v5 [options]
 ```
 
 :::note
@@ -73,7 +73,7 @@ The create command simplifies user creation. To create a user interactively:
 <Tabs>
   <TabItem label="Docker">
     ```sh
-    docker run -i -t --rm ghcr.io/steveiliop56/tinyauth:v5 user create --interactive
+    docker run -i -t --rm ghcr.io/tinyauthapp/tinyauth:v5 user create --interactive
     ```
   </TabItem>
   <TabItem label="Binary">
@@ -89,7 +89,7 @@ This launches an interactive TUI to input a username and password, generating th
 <Tabs>
   <TabItem label="Docker">
     ```sh
-    docker run -i -t --rm ghcr.io/steveiliop56/tinyauth:v5 user create --username user@example.com --password password
+    docker run -i -t --rm ghcr.io/tinyauthapp/tinyauth:v5 user create --username user@example.com --password password
     ```
   </TabItem>
   <TabItem label="Binary">
@@ -114,7 +114,7 @@ The verify command checks if a username and password match the `username:hash`. 
 <Tabs>
   <TabItem label="Docker">
     ```sh
-    docker run -i -t --rm ghcr.io/steveiliop56/tinyauth:v5 user verify --interactive
+    docker run -i -t --rm ghcr.io/tinyauthapp/tinyauth:v5 user verify --interactive
     ```
   </TabItem>
   <TabItem label="Binary">
@@ -129,7 +129,7 @@ A TUI prompts for the `username:hash:secret`, username, password and optional TO
 <Tabs>
   <TabItem label="Docker">
     ```sh
-    docker run -i -t --rm ghcr.io/steveiliop56/tinyauth:v5 user verify --user 'user@example.com:$2a$10$UdLYoJ5lgPsC0RKqYH/jMua7zIn0g9kPqWmhYayJYLaZQ/FTmH2/u' --username user@example.com --password password
+    docker run -i -t --rm ghcr.io/tinyauthapp/tinyauth:v5 user verify --user 'user@example.com:$2a$10$UdLYoJ5lgPsC0RKqYH/jMua7zIn0g9kPqWmhYayJYLaZQ/FTmH2/u' --username user@example.com --password password
     ```
   </TabItem>
   <TabItem label="Binary">
@@ -158,7 +158,7 @@ Tinyauth can auto-generate TOTP codes for you, the combination is `username:hash
 <Tabs>
   <TabItem label="Docker">
     ```sh
-    docker run -i -t --rm ghcr.io/steveiliop56/tinyauth:v5 totp generate --interactive
+    docker run -i -t --rm ghcr.io/tinyauthapp/tinyauth:v5 totp generate --interactive
     ```
   </TabItem>
   <TabItem label="Binary">
@@ -173,7 +173,7 @@ This prompts for the current `username:hash` and generates a `username:hash:secr
 <Tabs>
   <TabItem label="Docker">
     ```sh
-    docker run -i -t --rm ghcr.io/steveiliop56/tinyauth:v5 totp generate --user 'user@example.com:$2a$10$UdLYoJ5lgPsC0RKqYH/jMua7zIn0g9kPqWmhYayJYLaZQ/FTmH2/u'
+    docker run -i -t --rm ghcr.io/tinyauthapp/tinyauth:v5 totp generate --user 'user@example.com:$2a$10$UdLYoJ5lgPsC0RKqYH/jMua7zIn0g9kPqWmhYayJYLaZQ/FTmH2/u'
     ```
   </TabItem>
   <TabItem label="Binary">


### PR DESCRIPTION
As noted in [the v5.1.0 release notes](https://github.com/tinyauthapp/tinyauth/releases/tag/v5.1.0) the Docker image under `steveiliop56` will no longer be updated. This PR replaces it with the new one across the docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker and Docker Compose examples across setup guides, community integrations, and CLI references to use the current Tinyauth container image.
  * Refreshed deployment instructions for Kubernetes, Caddy, Nginx Proxy Manager, OIDC, TOTP, and supported integrations.
  * No configuration steps or non-Docker commands were changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->