### PR TITLE
Fix broken link in Kubernetes guide

### DIFF
--- a/src/content/docs/docs/guides/kubernetes.mdx
+++ b/src/content/docs/docs/guides/kubernetes.mdx
@@ -208,7 +208,7 @@ If everything deploys correctly, Tinyauth should start up with no errors and be 
 ## Using forward-auth
 
 Tinyauth officially supports only the Traefik proxy for forward-auth. However, it works with other proxies
-like Istio. Instructions on these proxies can be found in the [community guide](/docs/community/kubernetes.mdx).
+like Istio. Instructions on these proxies can be found in the [community guide](/docs/community/kubernetes/).
 
 To use Tinyauth as a forward-auth middleware in Traefik, just create a middleware using Traefik's CRD:
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the Kubernetes community guide link for non-Traefik forward-auth proxies.
  * Preserved the caution guidance in its collapsed state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->